### PR TITLE
update chart - tibiadata-api-go release 3.7.3

### DIFF
--- a/charts/tibiadata-api-go/Chart.yaml
+++ b/charts/tibiadata-api-go/Chart.yaml
@@ -24,10 +24,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "3.7.2"
+appVersion: "3.7.3"


### PR DESCRIPTION
- [tibiadata-api-go](https://github.com/TibiaData/tibiadata-api-go) release [v3.7.3](https://github.com/TibiaData/tibiadata-api-go/releases/tag/v3.7.3)