### PR TITLE
tibiadata-api-go release 4.0.1

### DIFF
--- a/charts/tibiadata-api-go/Chart.yaml
+++ b/charts/tibiadata-api-go/Chart.yaml
@@ -24,10 +24,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "4.0.0"
+appVersion: "4.0.1"


### PR DESCRIPTION
- [tibiadata-api-go](https://github.com/TibiaData/tibiadata-api-go) release [v4.0.1](https://github.com/TibiaData/tibiadata-api-go/releases/tag/v4.0.1)