### PR TITLE
feat: add image.digest option to tibidata-api-go chart

### DIFF
--- a/charts/tibiadata-api-go/Chart.yaml
+++ b/charts/tibiadata-api-go/Chart.yaml
@@ -24,7 +24,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.5
+version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/tibiadata-api-go/README.md
+++ b/charts/tibiadata-api-go/README.md
@@ -1,0 +1,46 @@
+# tibiadata-api-go Helm chart
+
+## Installation
+
+To add the tibiadata helm repo, run:
+
+```console
+helm repo add tibiadata https://charts.tibiadata.com
+helm repo update
+```
+
+To install a release named tibiadata-api-go, run:
+
+```console
+helm install tibiadata-api-go tibiadata/tibiadata-api-go
+```
+
+## Chart Values
+
+```console
+helm show values tibiadata/tibiadata-api-go
+```
+
+## Value Details
+
+### image
+
+Specify the container image to use for the deployment. `image.tag` For example, the following sets the image to the `ghcr.io/tibiadata/tibiadata-api-go` repo and the `v4.1.2` tag. The container pulls the image if not already present:
+
+```yaml
+image:
+  repository: ghcr.io/tibiadata/tibiadata-api-go
+  tag: v4.1.2
+  pullPolicy: IfNotPresent
+```
+
+The chart also supports specifying an image based on digest value:
+
+```yaml
+image:
+  repository: ghcr.io/tibiadata/tibiadata-api-go
+  digest: sha256:a6f902768cb71c0a0b391ec167146cd75bc07f063ad84f9022d98f7459f301bb
+  pullPolicy: IfNotPresent
+```
+
+If neither tag or digest is specified, the `appVersion` of the chart is used as a default.

--- a/charts/tibiadata-api-go/templates/_helpers.tpl
+++ b/charts/tibiadata-api-go/templates/_helpers.tpl
@@ -31,6 +31,19 @@ Create chart name and version as used by the chart label.
 {{- end }}
 
 {{/*
+Create chart image to be used by specifying tag or digest (including sha256: prefix)
+*/}}
+{{- define "tibiadata-api-go.image" -}}
+{{- $repository := .Values.image.repository -}}
+{{- if .Values.image.digest -}}
+{{- printf "%s@%s" $repository .Values.image.digest -}}
+{{- else -}}
+{{- $tag := default .Chart.AppVersion .Values.image.tag -}}
+{{- printf "%s:%s" $repository $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Common labels
 */}}
 {{- define "tibiadata-api-go.labels" -}}

--- a/charts/tibiadata-api-go/templates/deployment.yaml
+++ b/charts/tibiadata-api-go/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: {{ include "tibiadata-api-go.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/charts/tibiadata-api-go/values.yaml
+++ b/charts/tibiadata-api-go/values.yaml
@@ -7,8 +7,9 @@ replicaCount: 3
 image:
   repository: ghcr.io/tibiadata/tibiadata-api-go
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
+  # Overrides the image tag whose default is the chart appVersion (digest takes precedence over tag).
   tag: ""
+  digest: ""
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
- add `tibiadata-api-go.image` helper
- add readme for _tibiadata-api-go_ chart
- bump helm chart version to 1.1.0

fix #12