### PR TITLE
fix configmap keys to uppercase

### DIFF
--- a/charts/tibiadata-api-go/Chart.yaml
+++ b/charts/tibiadata-api-go/Chart.yaml
@@ -24,7 +24,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.0
+version: 1.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/tibiadata-api-go/values.yaml
+++ b/charts/tibiadata-api-go/values.yaml
@@ -28,14 +28,14 @@ configMap:
   create: true
   settings:
     # generic settings
-    debug_mode: false
+    DEBUG_MODE: false
     # Gin-related settings
-    gin_mode: release
-    gin_trusted_proxies: ""
+    GIN_MODE: release
+    GIN_TRUSTED_PROXIES: ""
     # TibiaData-related settings
-    tibiadata_edition: open-source
-    tibiadata_host: undefined
-    tibiadata_restriction_mode: false
+    TIBIADATA_EDITION: open-source
+    TIBIADATA_HOST: undefined
+    TIBIADATA_RESTRICTION_MODE: false
 
 podAnnotations: {}
 


### PR DESCRIPTION
[tibiadata-api-go](https://github.com/TibiaData/tibiadata-api-go) expects environment variables to be uppercase.
fixing configmap settings section in values.yaml to follow that.

rel #19