### PR TITLE
feat(ci): use sha instead of tag on steps

### DIFF
--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
 
       - name: Get current version
         id: get_version
@@ -22,14 +22,14 @@ jobs:
           echo "version=$(yq eval '.version' charts/${{ github.event.client_payload.chart_name }}/Chart.yaml)" >> $GITHUB_OUTPUT
 
       - name: Increment Semantic Version
-        uses: christian-draeger/increment-semantic-version@1.2.3
+        uses: christian-draeger/increment-semantic-version@18746485477492fd90f2664f8470b34d9208fa17 #1.2.3
         id: bump_version
         with:
           current-version: ${{ steps.get_version.outputs.version }}
           version-fragment: patch
 
       - name: Update Chart versions
-        uses: fjogeleit/yaml-update-action@v0.16.1
+        uses: fjogeleit/yaml-update-action@04ff6ec06568fd21197db746472e36cc425de850 #v0.16.1
         with:
           branch: bump/${{ github.event.client_payload.chart_name }}/${{ github.event.client_payload.release_version }}
           masterBranchName: ${{ github.event.repository.default_branch }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
       changed_charts: ${{ steps.chart_releaser.outputs.changed_charts }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
         with:
           fetch-depth: 0
 
@@ -29,20 +29,20 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 #v4.3.0
         with:
           version: latest
 
       - name: Run chart-releaser
         id: chart_releaser
-        uses: helm/chart-releaser-action@v1.7.0
+        uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f #v1.7.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_GENERATE_RELEASE_NOTES: true
 
       # see https://github.com/helm/chart-releaser/issues/183
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 #v3.5.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -63,16 +63,16 @@ jobs:
     needs: release
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
 
       - name: Get Helm Chart versions
         id: get_chart_versions
-        uses: jacobtomlinson/gha-read-helm-chart@0.1.3
+        uses: jacobtomlinson/gha-read-helm-chart@ca2f3b5038208efd3279dbe941e448d7ccdccbf6 #0.1.3
         with:
           path: ${{ needs.release.outputs.changed_charts }}
 
       - name: Trigger workflow in tibiadata-argocd-app-of-apps repo
-        uses: peter-evans/repository-dispatch@v3.0.0
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 #v3.0.0
         with:
           token: ${{ secrets.REPO_ACCESS_TOKEN }}
           repository: TibiaData/tibiadata-argocd-app-of-apps

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,23 +10,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
         with:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 #v4.3.0
         with:
           version: latest
 
       - name: Set up Python
-        uses: actions/setup-python@v5.6.0
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 #v5.6.0
         with:
           python-version: 3.x
           check-latest: true
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.7.0
+        uses: helm/chart-testing-action@0d28d3144d3a25ea2cc349d6e59901c4ff469b3b #v2.7.0
 
       - name: Run chart-testing (list-changed)
         id: list-changed
@@ -42,7 +42,7 @@ jobs:
 
       - name: Create kind cluster
         if: steps.list-changed.outputs.changed == 'true'
-        uses: helm/kind-action@v1.12.0
+        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 #v1.12.0
 
       - name: Run chart-testing (install)
         if: steps.list-changed.outputs.changed == 'true'


### PR DESCRIPTION
This pull request updates several GitHub Actions in workflow files to use explicit commit SHAs for each action, rather than floating version tags. This change improves security and reliability by ensuring the workflows always use the intended action versions, preventing unexpected updates or breaking changes.

closes #48 